### PR TITLE
Lps 121986

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -29,6 +29,8 @@ AUI.add(
 
 		var INTEGER_MIN_VALUE = 0;
 
+		var containerType = null;
+
 		var INTEGER_MAX_VALUE = 2147483647;
 
 		var SELECTOR_REPEAT_BUTTONS =
@@ -925,13 +927,27 @@ AUI.add(
 					);
 				},
 
-				renderUI() {
+				renderUI(newValue) {
 					var instance = this;
-
+					if(!newValue){
 					if (instance.get('repeatable')) {
 						instance.renderRepeatableUI();
-						instance.syncRepeatablelUI();
+						var name = instance.getRepeatedSiblings()[0].get('name');
+
+						if(name !== containerType ){
+							containerType = name;
+
+						}else {
+							instance.syncRepeatablelUI();
+						}
 					}
+					}else{
+						if (instance.get('repeatable')) {
+							instance.renderRepeatableUI();
+							instance.syncRepeatablelUI();
+						}
+					}
+
 
 					instance.syncLabel(instance.get('displayLocale'));
 
@@ -4221,7 +4237,7 @@ AUI.add(
 					instance.repeatableInstances = {};
 
 					instance.bindUI();
-					instance.renderUI();
+					instance.renderUI(0);
 				},
 
 				moveField(parentField, oldIndex, newIndex) {


### PR DESCRIPTION
Szia!

A koncepció az volt, hogy módosításnál működik csak rosszul, így kellett egy megoldás ami módosításnál is fixálja containereket úgy h nem rontja el z új létrehozását is. Szóval minden új típusú repeatable field első eleménél kihagyom a törlés gomb kirajzolását.

Ez egy nagyon prototípus kód. Valamiért az első típusnál néha lehet törölni az elsőt is, de mindig marad legalább egy.
Illetve kódszinten a globális változó nem tudom, h kóser e, kellett találnom egy helyet ahol teljes renderedés alatt megmarad a változóm.

Köszi,
Marci